### PR TITLE
StringBuffer to make _normalize faster

### DIFF
--- a/lib/src/unorm_dart_base.dart
+++ b/lib/src/unorm_dart_base.dart
@@ -28,12 +28,12 @@ UnormIterator _createIterator(_NormalizeMode mode, String str) {
 String _normalize(_NormalizeMode mode, String str) {
   initUCharCache();
   UnormIterator iterator = _createIterator(mode, str);
-  String ret = "";
+  StringBuffer ret = StringBuffer();
   UChar? uchar;
   while ((uchar = iterator.next()) != null) {
-    ret += uchar.toString();
+    ret.writeCharCode(uchar!.codepoint);
   }
-  return ret;
+  return ret.toString();
 }
 
 /// Normalizes provided [str] with Canonical Decomposition.


### PR DESCRIPTION
_normalize function should use StringBuilder to make the string concatenation faster.