### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.2
+
+- Update Unicode data to version 17 ([#41](https://github.com/yshrsmz/unorm-dart/pull/41))
+- Update dependency dart to v3.9.4 ([#40](https://github.com/yshrsmz/unorm-dart/pull/40))
+
+
 ## 0.3.1+1
 
 - Update supported Unicode version to 16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A Dart implementation of Unicode normalization (NFC, NFD, NFKC, NFKD) supporting Unicode 16.0. This is a Dart port of the JavaScript [walling/unorm](https://github.com/walling/unorm) library.
+A Dart implementation of Unicode normalization (NFC, NFD, NFKC, NFKD) supporting Unicode 17.0. This is a Dart port of the JavaScript [walling/unorm](https://github.com/walling/unorm) library.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Unit Test](https://github.com/yshrsmz/unorm-dart/actions/workflows/pull_request.yml/badge.svg)](https://github.com/yshrsmz/unorm-dart/actions/workflows/pull_request.yml)
 
-Unicode 16.0 Normalization - NFC, NFD, NFKC, NFKD
+Unicode 17.0 Normalization - NFC, NFD, NFKC, NFKD
 
 Dart2 port of [unorm](https://github.com/walling/unorm)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: unorm_dart
-description: Unicode 16.0 Normalization - NFC, NFD, NFKC, NFKD.
+description: Unicode 17.0 Normalization - NFC, NFD, NFKC, NFKD.
   This is a Dart port of [walling/unorm](https://github.com/walling/unorm).
-version: 0.3.1+1
+version: 0.3.2
 homepage: https://github.com/yshrsmz/unorm-dart
 
 environment:


### PR DESCRIPTION
## Summary
- Update Unicode data to version 17
- Update Dart SDK to v3.9.4
- Bump version to 0.3.2

## Changes
- Updated Unicode normalization data to version 17 (#41)
- Updated Dart SDK dependency to v3.9.4 (#40)
- Updated version in pubspec.yaml to 0.3.2
- Updated CHANGELOG.md with release notes
- Updated documentation (README.md, CLAUDE.md) to reflect Unicode 17.0 support